### PR TITLE
Don't make drafts clickable

### DIFF
--- a/pages/articles.tsx
+++ b/pages/articles.tsx
@@ -52,12 +52,23 @@ function ArticleRow({ article }: { article: Article }): React.ReactElement {
   return (
     <div className="border-b border-gray-200 my-2 py-4 flex justify-between items-center">
       <div>
-        <Link href={`/articles/i/${article.id}`}>
-          <a className="text-3xl font-serif flex items-center hover:text-primary hover:cursor-pointer">
-            {article.title}
-            &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
-          </a>
-        </Link>
+        {
+          article.draft
+            ? (
+              <div className="text-3xl font-serif flex items-center">
+                {article.title}
+                &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
+              </div>
+            )
+            : (
+              <Link href={`/articles/i/${article.id}`}>
+                <a className="text-3xl font-serif flex items-center hover:text-primary hover:cursor-pointer">
+                  {article.title}
+                  &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
+                </a>
+              </Link>
+            ) 
+        }
 
         <div className="text-lg w-full mb-4">
           {article?.summary}

--- a/pages/write.tsx
+++ b/pages/write.tsx
@@ -38,7 +38,7 @@ const saveArticle = debounce((createOrUpdateArticle, input: CreateOrUpdateArticl
 const Write: NextPage = (): React.ReactElement => {
   const [title, setTitle] = useState('');
   const [summary, setSummary] = useState('');
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState('[{"type":"paragraph","children":[{"text":""}]}]');
   const [subscribersOnly, setSubscribersOnly] = useState(false);
   const [createOrUpdateArticle, { data, loading: mutationLoading, error: mutationError, called }] = useMutation(CREATE_OR_UPDATE_ARTICLE);
 


### PR DESCRIPTION
This PR:
- [x] Adds an empty value for saving an article
- [x] Adjusts the articles page so drafts aren't clickable