### PR TITLE
Refactor queries for composability

### DIFF
--- a/components/ArticleRow.tsx
+++ b/components/ArticleRow.tsx
@@ -1,0 +1,46 @@
+
+import Link from 'next/link';
+import { formatDistanceToNow } from 'date-fns';
+
+import { Article } from '../generated/graphql';
+
+function ArticleRow({ article }: { article: Article }): React.ReactElement {
+  return (
+    <div className="border-b border-gray-200 my-2 py-4 flex justify-between items-center">
+      <div>
+        {
+          article.draft
+            ? (
+              <div className="text-3xl font-serif flex items-center">
+                {article.title}
+                  &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
+              </div>
+            )
+            : (
+              <Link href={`/articles/i/${article.id}`}>
+                <a className="text-3xl font-serif flex items-center hover:text-primary hover:cursor-pointer">
+                  {article.title}
+                    &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
+                </a>
+              </Link>
+            )
+        }
+
+        <div className="text-lg w-full mb-4">
+          {article?.summary}
+        </div>
+
+        <div className="text-xs">
+          Updated {formatDistanceToNow(new Date(article.updatedAt))} ago
+          </div>
+      </div>
+
+      <div>
+        <div className="inline hover:text-primary hover:cursor-pointer font-medium mr-4">Edit</div>
+        <div className="inline text-red-600 hover:text-red-900 hover:cursor-pointer font-medium">Delete</div>
+      </div>
+    </div>
+  );
+}
+
+export default ArticleRow;

--- a/components/ArticleTypeSelector.tsx
+++ b/components/ArticleTypeSelector.tsx
@@ -1,0 +1,24 @@
+type ArticleTypeSelectorProps = {
+  articleType: string;
+  setArticleType: (name: string) => void;
+  name: string;
+  count: number;
+}
+
+export function ArticleTypeSelector({
+  articleType,
+  setArticleType,
+  name,
+  count,
+}: ArticleTypeSelectorProps): React.ReactElement {
+  return (
+    <div
+      className={`${articleType !== name.toLowerCase() && 'text-gray-500'} inline mr-8 text-2xl hover:cursor-pointer`}
+      onClick={(): void => setArticleType(name.toLowerCase())}
+    >
+      {name} ({count})
+    </div>
+  );
+}
+
+export default ArticleTypeSelector;

--- a/components/DiscoverArticles.tsx
+++ b/components/DiscoverArticles.tsx
@@ -1,30 +1,17 @@
 import { useQuery } from '@apollo/react-hooks';
-import gql from 'graphql-tag';
 import { XMasonry, XBlock } from 'react-xmasonry';
 
 import { Article } from '../generated/graphql';
+import DiscoverArticlesQuery from '../queries/DiscoverArticlesQuery';
 
 import ArticleCard from './ArticleCard';
 
-export const ALL_ARTICLES_QUERY = gql`
-  query articles {
-    articles {
-      id
-      title
-      headerImageURL
-      summary
-      content
-    }
-  }
-`;
-
 function DiscoverArticles(): React.ReactElement {
-  const { loading, error, data } = useQuery(ALL_ARTICLES_QUERY);
+  const { loading, error, data } = useQuery(DiscoverArticlesQuery);
 
   if (error) return <div>Error</div>;
   if (loading) return <div>Loading</div>;
   
-
   return (
     <XMasonry>
       {data.articles.map((article: Article) => {

--- a/pages/articles.tsx
+++ b/pages/articles.tsx
@@ -1,96 +1,21 @@
 import { NextPage } from 'next';
-import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 import { useState } from 'react';
-import Link from 'next/link';
-import { formatDistanceToNow } from 'date-fns';
 
 import { Article } from '../generated/graphql';
+import ArticlesSummaryQuery from '../queries/ArticlesSummaryQuery';
 
 import { useAuth } from '../hooks/useAuth';
 
 import { withApollo } from '../lib/apollo';
 import withLayout from '../components/withLayout';
-
-export const ARTICLES_BY_USER = gql`
-  query articles($userId: ID!) {
-    articlesByUser(userId: $userId) {
-      id
-      title
-      summary
-      updatedAt
-      subscribersOnly
-      draft
-    }
-  }
-`;
-
-type ArticleTypeSelectorProps = {
-  articleType: string;
-  setArticleType: (name: string) => void;
-  name: string;
-  count: number;
-}
-
-function ArticleTypeSelector({
-  articleType,
-  setArticleType,
-  name,
-  count,
-}: ArticleTypeSelectorProps): React.ReactElement {
-  return (
-    <div
-      className={`${articleType !== name.toLowerCase() && 'text-gray-500'} inline mr-8 text-2xl hover:cursor-pointer`}
-      onClick={(): void => setArticleType(name.toLowerCase())}
-    >
-      {name} ({count})
-    </div>
-  );
-}
-
-function ArticleRow({ article }: { article: Article }): React.ReactElement {
-  return (
-    <div className="border-b border-gray-200 my-2 py-4 flex justify-between items-center">
-      <div>
-        {
-          article.draft
-            ? (
-              <div className="text-3xl font-serif flex items-center">
-                {article.title}
-                &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
-              </div>
-            )
-            : (
-              <Link href={`/articles/i/${article.id}`}>
-                <a className="text-3xl font-serif flex items-center hover:text-primary hover:cursor-pointer">
-                  {article.title}
-                  &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
-                </a>
-              </Link>
-            ) 
-        }
-
-        <div className="text-lg w-full mb-4">
-          {article?.summary}
-        </div>
-
-        <div className="text-xs">
-          Updated {formatDistanceToNow(new Date(article.updatedAt))} ago
-        </div>
-      </div>
-
-      <div>
-        <div className="inline hover:text-primary hover:cursor-pointer font-medium mr-4">Edit</div>
-        <div className="inline text-red-600 hover:text-red-900 hover:cursor-pointer font-medium">Delete</div>
-      </div>
-    </div>
-  );
-}
+import ArticleTypeSelector from '../components/ArticleTypeSelector';
+import ArticleRow from '../components/ArticleRow';
 
 const Articles: NextPage = (): React.ReactElement => {
   const auth = useAuth();
   const userId = auth.userId || auth.user?.uid;
-  const { loading, error, data } = useQuery(ARTICLES_BY_USER, { variables: { userId } });
+  const { loading, error, data } = useQuery(ArticlesSummaryQuery, { variables: { userId } });
   const [articleType, setArticleType] = useState('drafts');
 
   if (error) return <div>Error</div>;

--- a/pages/articles/[...id].tsx
+++ b/pages/articles/[...id].tsx
@@ -1,41 +1,19 @@
 import { NextPage } from 'next';
-import gql from 'graphql-tag';
 import { useRouter } from 'next/router';
 import { useQuery } from '@apollo/react-hooks';
+
+import ArticleBySlugQuery from '../../queries/ArticleBySlugQuery';
+import ArticleByIdQuery from '../../queries/ArticleByIdQuery';
 
 import { withApollo } from '../../lib/apollo';
 import withLayout from '../../components/withLayout';
 import Editor from '../../components/Editor';
 
-export const ARTICLE_BY_SLUG_QUERY = gql`
-  query article($id: String!) {
-    articleBySlug(slug: $id) {
-      id
-      title
-      headerImageURL
-      summary
-      content
-    }
-  }
-`;
-
-export const ARTICLE_BY_ID_QUERY = gql`
-  query article($id: ID!) {
-    article(id: $id) {
-      id
-      title
-      headerImageURL
-      summary
-      content
-    }
-  }
-`;
-
 const Article: NextPage = (): React.ReactElement => {
   const router = useRouter();
   const { id: idParams } = router.query;
   const [idType, id] = idParams;
-  const articleQuery = idType === 's' ? ARTICLE_BY_SLUG_QUERY : ARTICLE_BY_ID_QUERY;
+  const articleQuery = idType === 's' ? ArticleBySlugQuery : ArticleByIdQuery;
 
   const { loading, error, data } = useQuery(articleQuery, { variables: { id } });
 

--- a/queries/ArticleByIdQuery.ts
+++ b/queries/ArticleByIdQuery.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+const ArticleByIdQuery = gql`
+  query article($id: ID!) {
+    article(id: $id) {
+      id
+      title
+      headerImageURL
+      summary
+      content
+    }
+  }
+`;
+
+export default ArticleByIdQuery;

--- a/queries/ArticleBySlugQuery.ts
+++ b/queries/ArticleBySlugQuery.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+const ArticleBySlugQuery = gql`
+  query article($id: String!) {
+    articleBySlug(slug: $id) {
+      id
+      title
+      headerImageURL
+      summary
+      content
+    }
+  }
+`;
+
+export default ArticleBySlugQuery;

--- a/queries/ArticlesSummaryQuery.ts
+++ b/queries/ArticlesSummaryQuery.ts
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+
+const ArticlesSummaryQuery = gql`
+  query articlesSummary($userId: ID!) {
+    articlesByUser(userId: $userId) {
+      id
+      title
+      summary
+      updatedAt
+      subscribersOnly
+      draft
+    }
+  }
+`;
+
+export default ArticlesSummaryQuery;

--- a/queries/CreateOrUpdateArticleMutation.ts
+++ b/queries/CreateOrUpdateArticleMutation.ts
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+const CreateOrUpdateArticleMutation = gql`
+  mutation createOrUpdateArticle($input: CreateOrUpdateArticleInput!) {
+    createOrUpdateArticle(input: $input) {
+      id
+    }
+  }
+`;
+
+export default CreateOrUpdateArticleMutation;

--- a/queries/DiscoverArticlesQuery.ts
+++ b/queries/DiscoverArticlesQuery.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+const DiscoverArticlesQuery = gql`
+  query articles {
+    articles {
+      id
+      title
+      headerImageURL
+      summary
+      content
+    }
+  }
+`;
+
+export default DiscoverArticlesQuery;


### PR DESCRIPTION
This PR:
- [x] Moves queries out into their own files
- [x] Refactors some components (`ArticleRow`, `ArticleTypeSelector`) to be their own files
- [x] Refetches a user's articles when they create a new one