### PR TITLE
Add the ability to edit and publish an article

### DIFF
--- a/components/ArticleRow.tsx
+++ b/components/ArticleRow.tsx
@@ -31,12 +31,18 @@ function ArticleRow({ article }: { article: Article }): React.ReactElement {
         </div>
 
         <div className="text-xs">
+          { article?.publishedAt ? `Published ${formatDistanceToNow(new Date(article.updatedAt))} ago | ` : ''}
           Updated {formatDistanceToNow(new Date(article.updatedAt))} ago
-          </div>
+        </div>
       </div>
 
       <div>
-        <div className="inline hover:text-primary hover:cursor-pointer font-medium mr-4">Edit</div>
+        <Link href={`/edit/${article.id}`}>
+          <a className="inline hover:text-primary hover:cursor-pointer font-medium mr-4">
+            Edit
+          </a>
+        </Link>
+
         <div className="inline text-red-600 hover:text-red-900 hover:cursor-pointer font-medium">Delete</div>
       </div>
     </div>

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -3,10 +3,19 @@ type Props = {
   onClick?: () => void;
   className?: string;
   thin?: boolean;
+  disabled?: boolean;
 }
 
-function Button({ children, onClick, className, thin }: Props): React.ReactElement {
-  const classes = `bg-primary hover:bg-secondary px-4 ${thin ? 'py-1' : 'py-2'} text-white rounded ${className}`
+function Button({
+  children,
+  onClick,
+  className,
+  thin,
+  disabled: isDisabled,
+}: Props): React.ReactElement {
+  const yPadding = thin ? 'py-1' : 'py-2';
+  const disabled = isDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-secondary';
+  const classes = `bg-primary px-4 ${yPadding} ${disabled} text-white rounded ${className}`
   return (
     <button
       className={classes}

--- a/components/EditorContainer.tsx
+++ b/components/EditorContainer.tsx
@@ -1,0 +1,163 @@
+import { useState, useEffect } from 'react';
+import { Node } from 'slate';
+import { useMutation } from '@apollo/react-hooks';
+import TextareaAutosize from 'react-textarea-autosize';
+import debounce from 'lodash/debounce';
+import { FaSpinner } from 'react-icons/fa';
+import { useRouter } from 'next/router';
+
+import { useAuth } from '../hooks/useAuth';
+
+import Editor from '../components/Editor';
+import EditorNotification from '../components/EditorNotification';
+import Button from '../components/Button';
+import SubscribersOnlyToggle from '../components/SubcribersOnlyToggle';
+
+import { CreateOrUpdateArticleInput, Article } from '../generated/graphql';
+import CreateOrUpdateArticleMutation from '../queries/CreateOrUpdateArticleMutation';
+import PublishArticleMutation from '../queries/PublishArticleMutation';
+import ArticlesSummaryQuery from '../queries/ArticlesSummaryQuery';
+
+const saveArticle = debounce(({
+  createOrUpdateArticle,
+  input,
+  userId,
+}): void => {
+  createOrUpdateArticle({
+    variables: {
+      input,
+    },
+    refetchQueries: [{
+      query: ArticlesSummaryQuery,
+      variables: { userId },
+    }],
+  });
+}, 2000);
+
+const emptyDocumentString = '[{"type":"paragraph","children":[{"text":""}]}]';
+
+function EditorContainer({ article }: { article?: Article }): React.ReactElement {
+  const auth = useAuth();
+  const userId = auth.userId || auth.user?.uid;
+  const router = useRouter();
+  const [title, setTitle] = useState(article?.title || '');
+  const [summary, setSummary] = useState(article?.summary || '');
+  const [content, setContent] = useState(article?.content || emptyDocumentString);
+  const [subscribersOnly, setSubscribersOnly] = useState(article?.subscribersOnly || false);
+
+  const [createOrUpdateArticle, {
+    data: saveData,
+    loading: mutationLoading,
+    error: mutationError,
+    called,
+  }] = useMutation(CreateOrUpdateArticleMutation);
+
+  const [publishArticle, {
+    data: publishData,
+    loading: publishLoading,
+    error: publishError,
+    called: publishCalled,
+  }] = useMutation(PublishArticleMutation);
+
+
+  const articleId = saveData?.createOrUpdateArticle?.id || article?.id;
+  const publishable = !(!articleId || !title || content === emptyDocumentString);
+
+  useEffect(() => {
+    if (!title && !summary && !content || article?.draft === false) {
+      return;
+    }
+
+    const input: CreateOrUpdateArticleInput = {
+      title,
+      summary,
+      content,
+      subscribersOnly,
+    };
+
+    if (articleId) {
+      input.id = articleId;
+    }
+
+    saveArticle({
+      createOrUpdateArticle,
+      input,
+      userId,
+    });
+  }, [title, summary, content, subscribersOnly]);
+
+  const handleContentChange = (newContent: Node[]): void => {
+    const contentString = JSON.stringify(newContent);
+    setContent(contentString);
+  }
+
+  if (publishData) {
+    router.push(`/articles/i/${articleId}`);
+  }
+
+  const handlePublishArticle = (): void => {
+    if (!publishable) {
+      return;
+    }
+
+    publishArticle({
+      variables: { input: { id: articleId } },
+      refetchQueries: [{
+        query: ArticlesSummaryQuery,
+        variables: { userId },
+      }],
+    });
+  }
+
+  return (
+    <div className="sm:w-3/5 px-5 pt-5 container mx-auto relative">
+      <div className="flex justify-between sticky bg-white z-10 top-0 -mt-2 mb-4 py-2">
+        <SubscribersOnlyToggle
+          subscribersOnly={subscribersOnly}
+          setSubscribersOnly={setSubscribersOnly}
+        />
+
+        <div>
+          {/* <span className="mr-4 underline">
+            Schedule
+          </span> */}
+
+          <Button
+            thin
+            onClick={handlePublishArticle}
+            disabled={!publishable}
+            className="focus:outline-none"
+          >
+            {
+              publishLoading || (publishCalled && !publishError)
+                ? <FaSpinner className="icon-spin w-full px-4 my-1" />
+                : 'Publish'
+            }
+          </Button>
+        </div>
+      </div>
+
+      <TextareaAutosize 
+        className="focus:outline-none text-4xl font-serif w-full h-auto resize-none placeholder-gray-400"
+        placeholder="Title"
+        value={title}
+        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void => setTitle(e.target.value)}
+      >
+      </TextareaAutosize>
+
+      <TextareaAutosize 
+        className="focus:outline-none text-xl w-full h-auto resize-none placeholder-gray-400 mb-4"
+        placeholder="Add an optional summary"
+        value={summary}
+        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void => setSummary(e.target.value)}
+      >
+      </TextareaAutosize>
+
+      <Editor initialValue={JSON.parse(content)} setContent={handleContentChange} />
+
+      <EditorNotification saving={mutationLoading} error={mutationError || publishError} called={called} />
+    </div>
+  );
+}
+
+export default EditorContainer;

--- a/pages/edit/[id].tsx
+++ b/pages/edit/[id].tsx
@@ -1,0 +1,27 @@
+import { NextPage } from 'next';
+import Error from 'next/error';
+import { useRouter } from 'next/router';
+import { useQuery } from '@apollo/react-hooks';
+
+import ArticleByIdQuery from '../../queries/ArticleByIdQuery';
+
+import { withApollo } from '../../lib/apollo';
+import withLayout from '../../components/withLayout';
+import EditorContainer from '../../components/EditorContainer';
+
+const Edit: NextPage = (): React.ReactElement => {
+  const router = useRouter();
+  const { id } = router.query;
+  const { loading, error, data } = useQuery(ArticleByIdQuery, { variables: { id } });
+
+  if (error) return <div>Error</div>;
+  if (loading) return <div>Loading</div>;
+
+  const { article } = data;
+
+  return (
+    <EditorContainer article={article} />
+  );
+}
+
+export default withApollo({ ssr: true })(withLayout(Edit));

--- a/pages/write.tsx
+++ b/pages/write.tsx
@@ -1,120 +1,12 @@
-import { useState, useEffect } from 'react';
 import { NextPage } from 'next';
-import { Node } from 'slate';
-import { useMutation } from '@apollo/react-hooks';
-import TextareaAutosize from 'react-textarea-autosize';
-import debounce from 'lodash/debounce';
-
-import { useAuth } from '../hooks/useAuth';
 
 import { withApollo } from '../lib/apollo';
 import withLayout from '../components/withLayout';
-import Editor from '../components/Editor';
-import EditorNotification from '../components/EditorNotification';
-import Button from '../components/Button';
-import SubscribersOnlyToggle from '../components/SubcribersOnlyToggle';
-
-import { CreateOrUpdateArticleInput } from '../generated/graphql';
-import CreateOrUpdateArticleMutation from '../queries/CreateOrUpdateArticleMutation';
-import ArticlesSummaryQuery from '../queries/ArticlesSummaryQuery';
-
-const saveArticle = debounce(({
-  createOrUpdateArticle,
-  input,
-  data,
-  userId,
-}): void => {
-  if (data?.createOrUpdateArticle?.id) {
-    input.id = data.createOrUpdateArticle.id;
-  }
-
-  createOrUpdateArticle({
-    variables: {
-      input,
-    },
-    refetchQueries: [{
-      query: ArticlesSummaryQuery,
-      variables: { userId },
-    }]
-  });
-}, 2000);
+import EditorContainer from '../components/EditorContainer';
 
 const Write: NextPage = (): React.ReactElement => {
-  const auth = useAuth();
-  const userId = auth.userId || auth.user?.uid;
-  const [title, setTitle] = useState('');
-  const [summary, setSummary] = useState('');
-  const [content, setContent] = useState('[{"type":"paragraph","children":[{"text":""}]}]');
-  const [subscribersOnly, setSubscribersOnly] = useState(false);
-  const [createOrUpdateArticle, {
-    data,
-    loading: mutationLoading,
-    error: mutationError,
-    called,
-  }] = useMutation(CreateOrUpdateArticleMutation);
-
-  useEffect(() => {
-    if (!title && !summary && !content) {
-      return;
-    }
-
-    const input: CreateOrUpdateArticleInput = {
-      title,
-      summary,
-      content,
-      subscribersOnly,
-    };
-
-    saveArticle({
-      createOrUpdateArticle,
-      input,
-      data,
-      userId,
-    });
-  }, [title, summary, content, subscribersOnly]);
-
-  const handleContentChange = (newContent: Node[]): void => {
-    const contentString = JSON.stringify(newContent);
-    setContent(contentString);
-  }
-
   return (
-    <div className="sm:w-3/5 px-5 pt-5 container mx-auto relative">
-      <div className="flex justify-between sticky bg-white z-10 top-0 -mt-2 mb-4 py-2">
-        <SubscribersOnlyToggle
-          subscribersOnly={subscribersOnly}
-          setSubscribersOnly={setSubscribersOnly}
-        />
-
-        <div>
-          {/* <span className="mr-4 underline">
-            Schedule
-          </span> */}
-
-          <Button thin>
-            Publish
-          </Button>
-        </div>
-      </div>
-
-      <TextareaAutosize 
-        className="focus:outline-none text-4xl font-serif w-full h-auto resize-none placeholder-gray-400"
-        placeholder="Title"
-        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void => setTitle(e.target.value)}
-      >
-      </TextareaAutosize>
-
-      <TextareaAutosize 
-        className="focus:outline-none text-xl w-full h-auto resize-none placeholder-gray-400 mb-4"
-        placeholder="Add an optional summary"
-        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void => setSummary(e.target.value)}
-      >
-      </TextareaAutosize>
-
-      <Editor setContent={handleContentChange} />
-
-      <EditorNotification saving={mutationLoading} error={mutationError} called={called} />
-    </div>
+    <EditorContainer />
   );
 }
 

--- a/queries/ArticleByIdQuery.ts
+++ b/queries/ArticleByIdQuery.ts
@@ -8,6 +8,8 @@ const ArticleByIdQuery = gql`
       headerImageURL
       summary
       content
+      userId
+      subscribersOnly
     }
   }
 `;

--- a/queries/ArticlesSummaryQuery.ts
+++ b/queries/ArticlesSummaryQuery.ts
@@ -7,6 +7,7 @@ const ArticlesSummaryQuery = gql`
       title
       summary
       updatedAt
+      publishedAt
       subscribersOnly
       draft
     }

--- a/queries/PublishArticleMutation.ts
+++ b/queries/PublishArticleMutation.ts
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+const PublishArticleMutation = gql`
+  mutation publishArticle($input: PublishArticleInput!) {
+    publishArticle(input: $input) {
+      id
+    }
+  }
+`;
+
+export default PublishArticleMutation;

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:4000
-# timestamp: Thu Mar 19 2020 13:45:22 GMT-0700 (Pacific Daylight Time)
+# timestamp: Thu Mar 19 2020 16:11:01 GMT-0700 (Pacific Daylight Time)
 
 directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE
 
@@ -17,6 +17,7 @@ type Article {
   draft: Boolean!
   createdAt: String!
   updatedAt: String!
+  publishedAt: String
   userId: String!
   subscribersOnly: Boolean!
   slug: String!
@@ -66,9 +67,10 @@ type Mutation {
 
 type Query {
   articles: [Article]
-  article(id: ID): Article
-  articleBySlug(slug: String): Article
-  articlesByUser(userId: ID): [Article]
+  article(id: ID!): Article
+  articleBySlug(slug: String!): Article
+  articlesByUser(userId: ID!): [Article]
+  publishArticle(id: ID!): Article
 }
 
 """The `Upload` scalar type represents a file upload."""


### PR DESCRIPTION
This PR:
- [x] Adds the ability to edit an article (reusing the same editor as the `/write` page)
- [x] Blocks publishing if you don't have a title and content
- [x] Adds the ability to publish an article
- [x] Adds `disable` to `Button`