### PR TITLE
Add and use hook to close the nav menu when clicking outside

### DIFF
--- a/components/NavMenu.tsx
+++ b/components/NavMenu.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { FiSettings } from 'react-icons/fi';
 import styled from '@emotion/styled'
 import Link from 'next/link';
 
 import { useAuth } from '../hooks/useAuth';
+import useOnClickOutside from '../hooks/useOnClickOutside';
 
 const Menu = styled.div`
   top: 22px;
@@ -35,10 +36,20 @@ function DisplayMenu(): React.ReactElement {
 }
 
 function NavMenu(): React.ReactElement {
+  const menuRef = useRef(null);
   const [display, setDisplay] = useState(false);
 
+  useOnClickOutside(menuRef, () => {
+    if (display) {
+      setDisplay(!display);
+    }
+  });
+
   return (
-    <div className="flex justify-end relative ml-4">
+    <div
+      className="flex justify-end relative ml-4"
+      ref={menuRef}
+    >
       <FiSettings
         onClick={(): void => setDisplay(!display)}
         className={`${display && 'text-gray-700'} hover:cursor-pointer hover:text-primary`}

--- a/hooks/useOnClickOutside.tsx
+++ b/hooks/useOnClickOutside.tsx
@@ -1,0 +1,37 @@
+import { useEffect, RefObject } from 'react';
+
+// Sourced from usehooks.com <3
+function useOnClickOutside(
+  ref: RefObject<HTMLElement>,
+  handler: (e: MouseEvent | TouchEvent) => void,
+): void {
+  useEffect(
+    () => {
+      const listener = (event: MouseEvent | TouchEvent): void => {
+        // Do nothing if clicking ref's element or descendent elements
+        if (!ref.current || ref.current.contains(event.target as Node)) {
+          return;
+        }
+
+        handler(event);
+      };
+
+      document.addEventListener('mousedown', listener);
+      document.addEventListener('touchstart', listener);
+
+      return (): void => {
+        document.removeEventListener('mousedown', listener);
+        document.removeEventListener('touchstart', listener);
+      };
+    },
+    // Add ref and handler to effect dependencies
+    // It's worth noting that because passed in handler is a new ...
+    // ... function on every render that will cause this effect ...
+    // ... callback/cleanup to run every render. It's not a big deal ...
+    // ... but to optimize you can wrap handler in useCallback before ...
+    // ... passing it into this hook.
+    [ref, handler]
+  );
+}
+
+export default useOnClickOutside;


### PR DESCRIPTION
This PR:
- [x] Adds a `useOnClickOutside` hook
- [x] Uses the `useOnClickOutside` hook to close the nav menu