### PR TITLE
Replace react-tooltip with in-house tooltip

### DIFF
--- a/components/ArticleRow.tsx
+++ b/components/ArticleRow.tsx
@@ -1,14 +1,15 @@
 
-import { useRef } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
 import { FiCopy } from 'react-icons/fi';
-import ReactTooltip from 'react-tooltip';
 
 import { Article } from '../generated/graphql';
 
+import Tooltip from './Tooltip';
+
 function ArticleRow({ article }: { article: Article }): React.ReactElement {
-  const copyIcon = useRef(null);
+  const [showCopiedTooltip, setShowCopiedTooltip] = useState(false);
 
   return (
     <div className="border-b border-gray-200 my-2 py-4 flex justify-between items-center">
@@ -46,17 +47,19 @@ function ArticleRow({ article }: { article: Article }): React.ReactElement {
           !article?.draft && article?.slug &&
           (
             <span
-              ref={copyIcon}
-              data-for="copied-tooltip"
-              data-tip="Copied!"
+              id={`${article.id}-copy`} 
+              className="relative"
               onClick={(): void => {
                 navigator.clipboard.writeText(`https://getbard.com/articles/s/${article.slug}`);
-                const el = copyIcon?.current || undefined;
-                setTimeout(() => ReactTooltip.hide(el), 2000);
+                setShowCopiedTooltip(true);
+                setTimeout(() => setShowCopiedTooltip(false), 2500);
               }}
             >
               <FiCopy className="block hover:cursor-pointer hover:text-primary mr-4 transition duration-150 ease-in-out" />
-              <ReactTooltip id="copied-tooltip" event="click" isCapture />
+              <Tooltip showTooltip={showCopiedTooltip} selector={`#${article.id}-copy`}>
+                A link to the article has been <br/>
+                copied to your clipboard.
+              </Tooltip>
             </span>
           )
         }

--- a/components/Portal.tsx
+++ b/components/Portal.tsx
@@ -9,10 +9,10 @@ function Portal({ children, selector }: {
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
-    ref.current = document.querySelector(selector)
-    setMounted(true)
+    ref.current = document.querySelector(selector);
+    setMounted(true);
   }, [selector])
-
+  
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
   return mounted ? createPortal(children, ref.current) : null

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,0 +1,20 @@
+import Portal from './Portal';
+
+function Tooltip({ children, showTooltip, selector }: {
+  children: React.ReactNode;
+  showTooltip: boolean;
+  selector: string;
+}): React.ReactElement {
+  const opacity = showTooltip ? '100' : '0';
+  const tooltipClasses = `opacity-${opacity} text-center bg-black text-white rounded-sm px-2 py-2 absolute z-10 -mt-20 right-0 whitespace-no-wrap transition duration-300 ease-in-out`;
+
+  return (
+    <Portal selector={selector}>
+      <span className={tooltipClasses}>
+        {children}
+      </span>
+    </Portal>
+  );
+}
+
+export default Tooltip;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-hook-form": "^5.0.3",
     "react-icons": "^3.9.0",
     "react-textarea-autosize": "^7.1.2",
-    "react-tooltip": "^4.1.2",
     "slate": "^0.57.1",
     "slate-history": "^0.57.1",
     "slate-react": "^0.57.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9842,13 +9842,6 @@ react-textarea-autosize@^7.1.2:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-tooltip@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.1.2.tgz#bc9f8620759518f6ef294198d082097e968d549c"
-  integrity sha512-AXQ5uumN/ZpPO6mlPrV52S1As1OOHhyp3pinWFEtTlpKojS8+CL5r/n0oiO8GR5hWqrvEONU34NEF01N2ODwqg==
-  dependencies:
-    prop-types "^15.7.2"
-
 react@16.13.0:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.0.tgz#d046eabcdf64e457bbeed1e792e235e1b9934cf7"


### PR DESCRIPTION
This PR:
- [x] Replaces `react-tooltip` with `Tooltip` (might not be as robust but we can expand as we need to)
- [x] Updates the copy of the "Copied" tool tip (see #34)