### PR TITLE
Block content that is for subscribers only

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { formatDistanceStrict } from 'date-fns';
+import { FiFeather } from 'react-icons/fi';
 
 import { Article } from '../generated/graphql';
 
@@ -10,6 +11,10 @@ const ArticleCardDiv = styled.div`
 
     h1 {
       color: #616161;
+    }
+
+    span {
+      display: flex;
     }
   }
 `;
@@ -31,11 +36,27 @@ function ArticleCard({ article }: { article: Article }): React.ReactElement {
   return (
     <Link href={articleHref}>
       <ArticleCardDiv className="p-4 border border-gray-300 rounded-sm hover:cursor-pointer transition duration-150 ease-in flex justify-between flex-col">
-        {article?.headerImageURL && <ArticleCardImage className="flex-grow h-40 rounded-t-sm -mt-3 -mx-3 mb-3 transition duration-150 ease-in" url={article.headerImageURL} />}
+        {
+          article?.headerImageURL &&
+          <ArticleCardImage className="flex-grow flex items-end h-40 rounded-t-sm -mt-3 -mx-3 mb-3" url={article.headerImageURL}>
+            {
+              article?.subscribersOnly && (
+                <span className="bg-white rounded-tr-sm pl-1 pt-1 pr-2 hidden items-center text-xs text-primary font-sans">
+                  <FiFeather className="mr-1" /> Supporters Only
+                </span>
+              )
+            }
+          </ArticleCardImage>
+        }
       
         <div>
-          <h1 className="font-serif font-bold text-xl transition duration-150 ease-in">{article.title}</h1>
-          <div className="text-gray-600 text-sm">{article.summary}</div>
+          <h1 className="font-serif font-bold text-xl transition duration-150 ease-in">
+            {article.title}
+          </h1>
+
+          <div className="text-gray-600 text-sm">
+            {article.summary}
+          </div>
           
           <div className="flex justify-between text-xs align-center font-bold mt-2">
             <div className="text-gray-700">

--- a/components/ArticleRow.tsx
+++ b/components/ArticleRow.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
-import { FiCopy } from 'react-icons/fi';
+import { FiCopy, FiFeather } from 'react-icons/fi';
 import { useMutation } from '@apollo/react-hooks';
 
 import { useAuth } from '../hooks/useAuth';
@@ -35,14 +35,26 @@ function ArticleRow({ article, refetch }: { article: Article; refetch: () => voi
             ? (
               <div className="text-3xl font-serif flex items-center">
                 {article.title}
-                  &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
+                {
+                  article.subscribersOnly && (
+                    <span className="text-2xl uppercase tracking-widest text-primary px-2 py-1 font-sans">
+                      <FiFeather />
+                    </span>
+                  )
+                }
               </div>
             )
             : (
               <Link href={`/articles/i/${article.id}`}>
                 <a className="text-3xl font-serif flex items-center hover:text-primary hover:cursor-pointer transition duration-150 ease-in-out">
                   {article.title}
-                    &nbsp;{article.subscribersOnly && <span className="text-xs uppercase tracking-widest bg-primary rounded-full text-white px-2 py-1 font-sans">Premium</span>}
+                  {
+                    article.subscribersOnly && (
+                      <span className="text-2xl uppercase tracking-widest text-primary px-2 py-1 font-sans">
+                        <FiFeather />
+                      </span>
+                    )
+                  }
                 </a>
               </Link>
             )

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -4,6 +4,7 @@ type Props = {
   className?: string;
   thin?: boolean;
   disabled?: boolean;
+  secondary?: boolean;
 }
 
 function Button({
@@ -12,10 +13,16 @@ function Button({
   className,
   thin,
   disabled: isDisabled,
+  secondary,
 }: Props): React.ReactElement {
   const yPadding = thin ? 'py-1' : 'py-2';
-  const disabled = isDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-secondary';
-  const classes = `transition duration-150 ease-in-out bg-primary px-4 ${yPadding} ${disabled} text-white rounded ${className}`
+  const textColor = secondary ? 'text-primary' : 'text-white';
+  const bgColor = secondary ? 'bg-white' : 'bg-primary';
+  const bgHoverColor = secondary ? 'hover:bg-primary' : 'hover:bg-secondary';
+  const borderHoverColor = secondary ? 'hover:border-primary' : 'hover:border-secondary';
+
+  const disabled = isDisabled ? 'opacity-50 cursor-not-allowed' : bgHoverColor;
+  const classes = `border border-primary ${borderHoverColor} transition duration-150 ease-in-out ${bgColor} px-4 ${yPadding} ${disabled} ${textColor} hover:text-white rounded ${className}`
   return (
     <button
       className={classes}

--- a/components/SubcribersOnlyToggle.tsx
+++ b/components/SubcribersOnlyToggle.tsx
@@ -36,7 +36,7 @@ function SubscribersOnlyToggle({ subscribersOnly, setSubscribersOnly }: Props): 
         </ToggleBackground>
 
         <div className="ml-2">
-          {subscribersOnly ? 'Subscribers Only' : 'Public'}
+          {subscribersOnly ? 'Supporters Only' : 'Public'}
         </div>
       </label>
     </div>

--- a/components/withLayout.tsx
+++ b/components/withLayout.tsx
@@ -27,8 +27,6 @@ function withLayout(PageComponent: NextPage): NextPage {
         <Nav />
   
         {(isAuthenticated || !protectedRoutes.includes(router.pathname)) && <PageComponent />}
-
-        <div className="pt-5"></div>
       </div>
     );
   }

--- a/pages/[username].tsx
+++ b/pages/[username].tsx
@@ -13,6 +13,7 @@ import ArticlesSummaryQuery from '../queries/ArticlesSummaryQuery';
 import { withApollo } from '../lib/apollo';
 import withLayout from '../components/withLayout';
 import Button from '../components/Button';
+import ButtonLink from '../components/ButtonLink';
 import ProfileSectionSelector from '../components/ProfileSectionSelector';
 import ArticleRow from '../components/ArticleRow';
 
@@ -65,8 +66,8 @@ const Author: NextPage = (): React.ReactElement => {
   } = useQuery(ArticlesSummaryQuery, { variables: { userId: user.id } });
 
   return (
-    <div className="px-5 pt-5 grid grid-cols-3">
-      <div>
+    <div className="px-5 pt-5 grid grid-cols-4">
+      <div className="text-center">
         <div className="text-4xl font-serif font-bold">{user.firstName} {user.lastName}</div>
         <div className="text-xl text-gray-600 mb-2">{username}</div>
         
@@ -76,13 +77,17 @@ const Author: NextPage = (): React.ReactElement => {
           <div>{user?.following?.length || 0} followers</div>
         </div>
 
-        <div>
-          <Button className="mr-4">Donate</Button>
-          <Button>Subscribe</Button>
+        <div className="flex justify-center flex-col items-center">
+          <Button>Become a supporter</Button>
+
+          <div className="mt-2">
+            <Button className="mr-2" secondary>Follow</Button>
+            <Button secondary>One-Time Support</Button>
+          </div>
         </div>
       </div>
 
-      <div className="col-span-2">
+      <div className="col-span-3">
         <div className="mb-6 pb-4 border-b border-gray-300">
           <ProfileSectionSelector
             name="Articles"

--- a/pages/articles/[...id].tsx
+++ b/pages/articles/[...id].tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useQuery } from '@apollo/react-hooks';
 import { format } from 'date-fns';
+import styled from '@emotion/styled';
 
 import ArticleBySlugQuery from '../../queries/ArticleBySlugQuery';
 import ArticleByIdQuery from '../../queries/ArticleByIdQuery';
@@ -11,6 +12,35 @@ import { withApollo } from '../../lib/apollo';
 import withLayout from '../../components/withLayout';
 import Editor from '../../components/Editor';
 import HeaderImage from '../../components/HeaderImage';
+import Button from '../../components/Button';
+
+const GradientBlocker = styled.div`
+  min-height: 25vh;
+  width: 100%;
+  background: linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 100%);
+`;
+
+const ContentBlocker = ({ author }: { author: string }): React.ReactElement => {
+  return (
+    <div className="absolute top-0 left-0 right-0">
+        <GradientBlocker />
+
+        <div className="bg-white flex flex-col justify-center items-center pb-5">
+          <div className="mb-2">
+            {author} has made this content available to subscribers only.
+          </div>
+
+          <Button>
+            Support {author} to read this article
+          </Button>
+
+          <div className="mt-2">
+            Already a supporter? <Link href="/login"><a>Login to read</a></Link>
+          </div>
+        </div>
+    </div>
+  );
+}
 
 const Article: NextPage = (): React.ReactElement => {
   const router = useRouter();
@@ -24,7 +54,7 @@ const Article: NextPage = (): React.ReactElement => {
   if (loading) return <div>Loading</div>;
 
   const article = data?.article || data?.articleBySlug;
-  const authorName = `${article.author.firstName}${article.author?.lastName && ' ' + article.author.lastName[0] + '.'}`;
+  const authorName = `${article.author.firstName}${article.author?.lastName && ' ' + article.author.lastName}`;
 
   return (
     <div className="sm:w-3/5 px-5 py-5 container mx-auto relative">
@@ -54,10 +84,30 @@ const Article: NextPage = (): React.ReactElement => {
         </div>
       </div>
 
-      <Editor
-        readOnly
-        initialValue={JSON.parse(article.content)}
-      />
+      <div className="relative">
+        <Editor
+          readOnly
+          initialValue={JSON.parse(article.content)}
+        />
+
+        {
+          article?.subscribersOnly && article?.contentBlocked && (
+            <>
+              <div className="text-center font-bold mt-2 text-primary">
+                <div>
+                  Oh! You edited our HTML. We trimmed the content on the server but nice try!
+                </div>
+
+                <div>
+                  Please consider supporting <Link href={`/${article.author.username}`} ><a className="underline">{article.author.firstName}</a></Link>.
+                </div>
+              </div>
+
+              <ContentBlocker author={article.author.firstName} />
+            </>
+          )
+        }
+      </div>
     </div>
   );
 }

--- a/queries/ArticleByIdQuery.ts
+++ b/queries/ArticleByIdQuery.ts
@@ -10,6 +10,7 @@ const ArticleByIdQuery = gql`
       content
       userId
       subscribersOnly
+      contentBlocked
       publishedAt
       author {
         username

--- a/queries/ArticleBySlugQuery.ts
+++ b/queries/ArticleBySlugQuery.ts
@@ -9,6 +9,8 @@ const ArticleBySlugQuery = gql`
       summary
       content
       publishedAt
+      subscribersOnly
+      contentBlocked
       author {
         username
         firstName

--- a/queries/DiscoverArticlesQuery.ts
+++ b/queries/DiscoverArticlesQuery.ts
@@ -10,6 +10,7 @@ const DiscoverArticlesQuery = gql`
       content
       slug
       publishedAt
+      subscribersOnly
       author {
         username
         firstName


### PR DESCRIPTION
This PR:
- [x] Adds a blocker (gradient overlay) on content that is for subscribers only
- [x] Changes "subscribers" ---> "supporters"
- [x] Adds a `secondary` button
- [x] Includes minor stylistic changes to the profile page
- [x] Uses `FiFeather` to indicate `subscribersOnly` articles