### PR TITLE
Identify supporters only on small article cards

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -13,7 +13,7 @@ const ArticleCardDiv = styled.div`
       color: #616161;
     }
 
-    span {
+    .sub-only {
       display: flex;
     }
   }
@@ -41,7 +41,7 @@ function ArticleCard({ article }: { article: Article }): React.ReactElement {
           <ArticleCardImage className="flex-grow flex items-end h-40 rounded-t-sm -mt-3 -mx-3 mb-3" url={article.headerImageURL}>
             {
               article?.subscribersOnly && (
-                <span className="bg-white rounded-tr-sm pl-1 pt-1 pr-2 hidden items-center text-xs text-primary font-sans">
+                <span className="sub-only bg-white rounded-tr-sm pl-1 pt-1 pr-2 hidden items-center text-xs text-primary font-sans">
                   <FiFeather className="mr-1" /> Supporters Only
                 </span>
               )

--- a/components/SmallArticleCard.tsx
+++ b/components/SmallArticleCard.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { formatDistanceStrict } from 'date-fns';
+import { FiFeather } from 'react-icons/fi';
 
 import { Article } from '../generated/graphql';
 
@@ -9,7 +10,15 @@ const ArticleCardDiv = styled.div`
     h1 {
       color: #616161;
     }
+
+    .sub-only {
+      display: flex;
+    }
   }
+`;
+
+const SubOnlyIcon = styled.div`
+  grid-column: none;
 `;
 
 function SmallArticleCard({ article }: { article: Article }): React.ReactElement {
@@ -19,8 +28,28 @@ function SmallArticleCard({ article }: { article: Article }): React.ReactElement
   return (
     <Link href={articleHref}>
       <ArticleCardDiv className="py-4 px-2 mx-2 rounded-sm hover:cursor-pointer transition duration-150 ease-in">
-        <h1 className="font-serif font-bold transition duration-150 ease-in">{article.title}</h1>
-        {article.summary && <div className="text-gray-600 mt-1 text-sm">{article.summary}</div>}
+        <div className={`${article.subscribersOnly && 'grid grid-cols-8'}`}>
+          <h1 className="col-span-7 font-serif font-bold transition duration-150 ease-in">
+            {article.title}
+          </h1>
+
+          {
+            article.subscribersOnly && (
+              <SubOnlyIcon className="sub-only hidden items-center text-primary">
+                <FiFeather />
+              </SubOnlyIcon>
+            )
+          }
+        </div>
+        
+
+        {
+          article.summary && (
+            <div className="text-gray-600 mt-1 text-sm">
+              {article.summary}
+            </div>
+          )
+        }
         
         <div className="flex justify-between text-xs align-center font-bold mt-2">
           <div className="text-gray-700">

--- a/pages/articles/[...id].tsx
+++ b/pages/articles/[...id].tsx
@@ -26,7 +26,7 @@ const ContentBlocker = ({ author }: { author: string }): React.ReactElement => {
 
         <div className="bg-white flex flex-col justify-center items-center pb-10 pt-0 -mt-16">
           <div className="mb-2">
-            {author} has made this content available to subscribers only.
+            {author} has made this content available to supporters only.
           </div>
 
           <Button>


### PR DESCRIPTION
This PR helps identify `subscriberOnly` `SmallArticleCards` on the homepage. 

![image](https://user-images.githubusercontent.com/16005567/78079964-15ec0500-7362-11ea-9a6f-cf5937cee240.png)
