### PR TITLE
Send user info when creating a Stripe Checkout session

### DIFF
--- a/components/OneTimeSupportButton.tsx
+++ b/components/OneTimeSupportButton.tsx
@@ -13,7 +13,7 @@ type FormData = {
   donationAmount: number;
 };
 
-function OneTimeSupportButton(): React.ReactElement {
+function OneTimeSupportButton({ userId }: { userId: string }): React.ReactElement {
   const [displayDonationPrompt, setDisplayDonationPrompt] = useState(false);
   const { register, handleSubmit, errors } = useForm<FormData>();
   const [createStripeSession, { data, error, loading }] = useMutation(CreateStripeSessionMutation);
@@ -24,6 +24,7 @@ function OneTimeSupportButton(): React.ReactElement {
     createStripeSession({
       variables: {
         input: {
+          userId,
           amount: +donationAmount,
           redirectUrl: `${window.location.origin}/${router.query.username}`,
         },

--- a/pages/[username].tsx
+++ b/pages/[username].tsx
@@ -69,7 +69,7 @@ const Author: NextPage = (): React.ReactElement => {
 
   return (
     <div className="px-5 pt-5 grid grid-cols-4">
-      <div className="text-center">
+      <div className="text-center break-words">
         <div className="text-4xl font-serif font-bold">{user.firstName} {user.lastName}</div>
         <div className="text-xl text-gray-600 mb-2">{username}</div>
         
@@ -84,7 +84,7 @@ const Author: NextPage = (): React.ReactElement => {
 
           <div className="mt-2">
             <Button className="mr-2" secondary>Follow</Button>
-            <OneTimeSupportButton />
+            <OneTimeSupportButton userId={user.id} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR:
- [x] Sends a `userId` along when creating a Stripe Checkout session so we can send money to the authors
- [x] Adds some CSS to fix overflow issues on the profile page