### PR TITLE
Properly handle Unsplash download events

### DIFF
--- a/components/EditorImageInserter.tsx
+++ b/components/EditorImageInserter.tsx
@@ -15,7 +15,7 @@ import Portal from './Portal';
 import Modal from './Modal';
 
 const Menu = styled.div`
-  margin-top: -5.2px;
+  margin-top: -6px;
   transition-property: background-color, color;
   transition-duration: 500ms;
 `;

--- a/components/PhotoSelector.tsx
+++ b/components/PhotoSelector.tsx
@@ -47,6 +47,7 @@ const UnsplashThumbnail = ({
       onClick={(): void => onClick({
         id: photo.id,
         url: photo.urls.full,
+        downloadUrl: photo.urls.download_location,
         photographerName: photo.photographerName,
         photographerUrl: photo.photographerUrl,
       })}
@@ -110,7 +111,6 @@ export function PhotoSelector({
             }
           )
         }
-        {}
       </div>
     </UnsplashContainer>
   );

--- a/queries/UnsplashPhotoQuery.ts
+++ b/queries/UnsplashPhotoQuery.ts
@@ -9,6 +9,7 @@ const UnsplashPhotoQuery = gql`
       urls {
         full
         thumb
+        download_location
       }
     }
   }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:4000
-# timestamp: Tue Apr 14 2020 08:44:50 GMT-0700 (Pacific Daylight Time)
+# timestamp: Tue Apr 14 2020 11:48:20 GMT-0700 (Pacific Daylight Time)
 
 directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE
 
@@ -27,6 +27,7 @@ type Article {
 type ArticleHeaderImage {
   id: ID!
   url: String!
+  downloadUrl: String!
   photographerName: String!
   photographerUrl: String!
 }
@@ -34,6 +35,7 @@ type ArticleHeaderImage {
 input ArticleHeaderImageInput {
   id: ID!
   url: String!
+  downloadUrl: String!
   photographerName: String!
   photographerUrl: String!
 }
@@ -316,6 +318,7 @@ type UnsplashPhotoURLs {
   regular: String!
   small: String!
   thumb: String!
+  download_location: String!
 }
 
 input UpdateCommentInput {
@@ -332,7 +335,9 @@ type UpdateCommentPayload {
 scalar Upload
 
 input UploadImageInput {
-  image: String!
+  name: String!
+  type: String!
+  content: String!
 }
 
 type UploadImagePayload {


### PR DESCRIPTION
This PR:
- [x] Forwards Unsplash's `download_location` when saving so we [abide by their guidelines](https://help.unsplash.com/en/articles/2511258-guideline-triggering-a-download)
- [x] Fixes the Image Inserter positioning