### PR TITLE
Limit content length and trim where necessary

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -62,11 +62,19 @@ function ArticleCard({ article }: { article: Article }): React.ReactElement {
       
         <div>
           <h1 className="font-serif font-bold text-xl transition duration-150 ease-in">
-            {article.title}
+            {
+              article.title.length > 45
+                ? `${article.title.substr(0, article.title.lastIndexOf(' ', 45))}...`
+                : article.title
+            }
           </h1>
 
           <div className="text-gray-600 text-sm">
-            {article.summary}
+          {
+            article.summary && article.summary.length > 100
+              ? `${article.summary.substr(0, article.summary.lastIndexOf(' ', 100))}...`
+              : article.summary
+          }
           </div>
           
           <div className="text-xs mt-2 font-medium flex justify-between">

--- a/components/EditorContainer.tsx
+++ b/components/EditorContainer.tsx
@@ -217,6 +217,7 @@ function EditorContainer({ article }: { article?: Article }): React.ReactElement
           placeholder="Title"
           value={title}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void => setTitle(e.target.value)}
+          maxLength={80}
         >
         </TextareaAutosize>
 
@@ -225,6 +226,7 @@ function EditorContainer({ article }: { article?: Article }): React.ReactElement
           placeholder="Add an optional summary"
           value={summary}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void => setSummary(e.target.value)}
+          maxLength={200}
         >
         </TextareaAutosize>
 

--- a/components/EditorImageInserter.tsx
+++ b/components/EditorImageInserter.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { ReactEditor, useSlate } from 'slate-react';
-import { Transforms } from 'slate'
+import { Transforms, Editor } from 'slate'
 import styled from '@emotion/styled';
 import { FiImage } from 'react-icons/fi';
 import { useDropzone } from 'react-dropzone';
@@ -40,9 +40,15 @@ function EditorInsertImage(): React.ReactElement {
     if (data?.uploadImage?.url) {
       const text = { text: '' };
       const image = { type: 'image', url: data?.uploadImage?.url, children: [text] };
+
+      // Insert the image into the editor
       Transforms.insertNodes(editor, image);
       setDisplay(false);
       setError(null);
+
+      // Focus the editor
+      ReactEditor.focus(editor);
+      Transforms.select(editor, Editor.end(editor, []));
     }
   }, [loading]);
 

--- a/components/SmallArticleCard.tsx
+++ b/components/SmallArticleCard.tsx
@@ -36,7 +36,11 @@ function SmallArticleCard({ article }: { article: Article }): React.ReactElement
       <ArticleCardContainer className="pt-1 pb-2 px-2 rounded-sm hover:cursor-pointer transition duration-150 ease-in">
         <div className={`${article.subscribersOnly && 'grid grid-cols-8'}`}>
           <h1 className="col-span-7 font-serif font-bold transition duration-150 ease-in">
-            {article.title}
+            {
+              article.title.length > 45
+                ? `${article.title.substr(0, article.title.lastIndexOf(' ', 45))}...`
+                : article.title
+            }
           </h1>
 
           {
@@ -52,7 +56,11 @@ function SmallArticleCard({ article }: { article: Article }): React.ReactElement
         {
           article.summary && (
             <div className="text-gray-600 mt-1 text-sm">
-              {article.summary}
+              {
+                article.summary.length > 100
+                  ? `${article.summary.substr(0, article.summary.lastIndexOf(' ', 100))}...`
+                  : article.summary
+              }
             </div>
           )
         }


### PR DESCRIPTION
This PR:
- [x] Resolves #97 
- [x] Trims content when it is too longer (we allow longer titles/summaries if people want, but trim them where necessary on the home page)
- [x] Focuses the editor when you insert an image