### PR TITLE
Keep comment value around when reply editor is closed

### DIFF
--- a/components/CommentEditor.tsx
+++ b/components/CommentEditor.tsx
@@ -28,7 +28,6 @@ const emptyValue = [{
   children: [{ text: '' }],
 }];
 
-
 type EditorContainerProps = {
   readOnly: boolean;
 }
@@ -47,6 +46,7 @@ function CommentEditor({
   initialValue,
   refetch,
   onSubmit,
+  setInitialValue,
 }: {
   resourceId: string;
   parentId?: string;
@@ -55,6 +55,7 @@ function CommentEditor({
   initialValue?: Node[];
   refetch?: () => void;
   onSubmit?: () => void;
+  setInitialValue?: (initialValue: any) => void;
 }): React.ReactElement {
   const auth = useAuth();
   const [value, setValue] = useState<Node[]>(initialValue || emptyValue);
@@ -85,6 +86,10 @@ function CommentEditor({
 
     if (called && !loading && onSubmit) {
       onSubmit();
+    }
+
+    if (called && !loading && setInitialValue) {
+      setInitialValue(emptyValue);
     }
   }, [createLoading, updateLoading]);
 
@@ -140,6 +145,11 @@ function CommentEditor({
 
   const handleChange = (value: Node[]): void => {
     setValue(value);
+
+    // Save the comment even when closing the editor
+    if (setInitialValue) {
+      setInitialValue(value);
+    }
   }
 
   const handleCreateComment = (): void => {

--- a/components/CommentRow.tsx
+++ b/components/CommentRow.tsx
@@ -14,6 +14,11 @@ import DateMeta from './DateMeta';
 import ReplyRow from './ReplyRow';
 import Notification from './Notification';
 
+const emptyValue = [{
+  type: 'paragraph',
+  children: [{ text: '' }],
+}];
+
 const CommentRow = ({
   comment,
   refetch,
@@ -25,6 +30,7 @@ const CommentRow = ({
   const replyEditorRef = useRef(null);
   const [showReplyEditor, setShowReplyEditor] = useState(false);
   const [readOnly, setReadOnly] = useState(true);
+  const [initialValue, setInitialValue] = useState<any | null>(null);
   const commentorName = auth.userId === comment.user.id
     ? 'You'
     : `${comment.user.firstName}${comment.user?.lastName && ' ' + comment.user.lastName}`;
@@ -36,6 +42,12 @@ const CommentRow = ({
       refetch();
     }
   }, [loading]);
+
+  useEffect(() => {
+    if (JSON.stringify(initialValue) === JSON.stringify(emptyValue)) {
+      setShowReplyEditor(false);
+    }
+  }, [initialValue]);
 
   useOnClickOutside(replyEditorRef, (): void => {
     setShowReplyEditor(false);
@@ -64,10 +76,11 @@ const CommentRow = ({
               className="m-2 border border-gray-300"
             >
               <CommentEditor
+                initialValue={initialValue}
+                setInitialValue={setInitialValue}
                 refetch={refetch}
                 resourceId={comment.resourceId}
                 parentId={comment.id || ''}
-                onSubmit={(): void => setShowReplyEditor(false)}
               />
             </div>
           )

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -12,7 +12,6 @@ import CommentsByResourceIdQuery from '../queries/CommentsByResourceIdQuery';
 import CommentEditor from './CommentEditor';
 import CommentRow from './CommentRow';
 import CommentsFallback from './CommentsFallback';
-import GenericError from './GenericError';
 
 function Comments({
   resourceId,


### PR DESCRIPTION
This PR will persist a comment around if the editor gets closed. That way you can open the editor back and still respond.